### PR TITLE
Bump Serilog from 4.0.0 to 4.0.1 in /src

### DIFF
--- a/src/MegaSchool1/MegaSchool1.csproj
+++ b/src/MegaSchool1/MegaSchool1.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageReference Include="QRCoder" Version="1.6.0" />
     <PackageReference Include="Riok.Mapperly" Version="3.6.0" />
+    <PackageReference Include="Serilog" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.Async" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.BrowserConsole" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />


### PR DESCRIPTION
Bumps Serilog from 4.0.0 to 4.0.1.

---
updated-dependencies:
- dependency-name: Serilog dependency-type: direct:production update-type: version-update:semver-patch ...