### PR TITLE
Bump Microsoft.AspNetCore.Components.Web

### DIFF
--- a/src/Flow.UI/Flow.UI.csproj
+++ b/src/Flow.UI/Flow.UI.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
         <PackageReference Include="MudBlazor" Version="7.15.0" />
         <PackageReference Include="Serilog" Version="4.2.0" />
     </ItemGroup>

--- a/src/Foundation.UI/Foundation.UI.csproj
+++ b/src/Foundation.UI/Foundation.UI.csproj
@@ -13,7 +13,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.2" />
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Components.Web" Version="9.0.2" />
         <PackageReference Include="MudBlazor" Version="7.15.0" />
         <PackageReference Include="OneOf" Version="3.0.271" />
     </ItemGroup>


### PR DESCRIPTION
…nts.Web (#70)

Bumps [Microsoft.AspNetCore.Components](https://github.com/dotnet/aspnetcore) and [Microsoft.AspNetCore.Components.Web](https://github.com/dotnet/aspnetcore). These dependencies needed to be updated together.

Updates `Microsoft.AspNetCore.Components` from 9.0.2 to 9.0.2
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v9.0.2...v9.0.2)

Updates `Microsoft.AspNetCore.Components.Web` from 9.0.1 to 9.0.2
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v9.0.1...v9.0.2)

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Components dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.AspNetCore.Components.Web dependency-type: direct:production update-type: version-update:semver-patch ...