### PR TITLE
Bump MudBlazor from 8.12.0 to 8.13.0

### DIFF
--- a/src/MegaSchool1/MegaSchool1.csproj
+++ b/src/MegaSchool1/MegaSchool1.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.9" PrivateAssets="all" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.3.0" />
     <PackageReference Include="Microsoft.FeatureManagement" Version="4.3.0" />
-    <PackageReference Include="MudBlazor" Version="8.12.0" />
+    <PackageReference Include="MudBlazor" Version="8.13.0" />
     <PackageReference Include="OneOf" Version="3.0.271" />
     <PackageReference Include="OneOf.SourceGenerator" Version="3.0.271" />
     <PackageReference Include="PublishSPAforGitHubPages.Build" Version="3.0.3" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: MudBlazor dependency-version: 8.13.0 dependency-type: direct:production update-type: version-update:semver-minor dependency-group: open-source-license ...