### PR TITLE
Bump Microsoft.NET.Test.Sdk from 17.14.1 to 18.0.0

### DIFF
--- a/src/MegaSchool1.Model.Test/MegaSchool1.Model.Test.csproj
+++ b/src/MegaSchool1.Model.Test/MegaSchool1.Model.Test.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="FsCheck" Version="3.3.1" />
     <PackageReference Include="FsCheck.NUnit" Version="3.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Components" Version="9.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.1.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />


### PR DESCRIPTION
---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-version: 18.0.0 dependency-type: direct:production update-type: version-update:semver-major dependency-group: open-source-license ...